### PR TITLE
pull時にmergeコミットを作るようになってしまっていた

### DIFF
--- a/home/dot_gitconfig
+++ b/home/dot_gitconfig
@@ -27,6 +27,8 @@
 [rerere]
     enabled = true
     autoupdate = true
+[pull]
+    ff = only
 [merge]
     conflictstyle = zdiff3
     ff = false


### PR DESCRIPTION
↓の設定のせいだと思う。

```gitconfig
[merge]
  ff = false
```

pullのときは個別に設定することで回避。