### PR TITLE
ファイルエクスプローラーを追加

### DIFF
--- a/home/dot_config/nvim/init.lua
+++ b/home/dot_config/nvim/init.lua
@@ -3,4 +3,5 @@ require("init_lazy")
 
 require("config.color-schema")
 require("config.finder")
+require("config.filer")
 

--- a/home/dot_config/nvim/lua/config/filer.lua
+++ b/home/dot_config/nvim/lua/config/filer.lua
@@ -1,0 +1,47 @@
+-- ファイルエクスプローラー(Neo-Tree)
+require("neo-tree").setup({
+    close_if_last_window = true, -- エディタを閉じたらファイルエクスプローラーも閉じる
+    filesystem = {
+        window = {
+            width = 30
+        }
+    },
+    window = {
+        mappings = {
+            -- ウィンドウを増減させるためにデフォルトの割当を削除する
+            ["l"] = "",
+        }
+    },
+})
+-- 起動時にファイルエクスプローラーも開く
+vim.api.nvim_create_autocmd("VimEnter", {
+    callback = function()
+        -- Gitから開かれたときはスキップする
+        local fname = vim.fn.expand("%:t")
+        if os.getenv("GIT_INDEX_FILE")
+            or fname == "COMMIT_EDITMSG"
+            or fname == "MERGE_MSG"
+            or fname == "TAG_EDITMSG" then
+                return
+        end
+
+        vim.cmd("Neotree filesystem reveal left")
+        -- ファイルが指定されていたらそちらにフォーカスする
+        if vim.fn.argc() > 0 then
+            vim.cmd("wincmd l")
+        end
+    end,
+})
+-- Ctrl-N でトグル
+vim.keymap.set("n", "<C-n>", ":Neotree toggle<CR>")
+
+-- Neo-treeのウィンドウの幅を増減させる
+vim.api.nvim_create_autocmd("FileType", {
+    pattern = "neo-tree",
+    callback = function()
+        local opts = { buffer = true, silent = true, noremap = true }
+        vim.keymap.set("n", "h", "<C-w><", opts)
+        vim.keymap.set("n", "l", "<C-w>>", opts)
+    end,
+})
+

--- a/home/dot_config/nvim/lua/plugins/neo-tree.lua
+++ b/home/dot_config/nvim/lua/plugins/neo-tree.lua
@@ -1,0 +1,11 @@
+-- ファイルエクスプローラー(Neo-Tree)
+return {
+    "nvim-neo-tree/neo-tree.nvim",
+    branch = "v3.x",
+    dependencies = {
+        "nvim-lua/plenary.nvim",
+        "nvim-tree/nvim-web-devicons",
+        "MunifTanjim/nui.nvim",
+    },
+}
+


### PR DESCRIPTION
`neo-tree.nvim`というプラグインを使う。

`<C-n>`で左にファイルエクスプローラーを表示する。エクスプローラー上で`h`, `l`でウィンドウ幅を変える（ファイル名が長くなってきたときのための対処）。
ウィンドウの切り替えは`<C-w>h`や`<C-w>l`でできる（vimの標準機能）。