### PR TITLE
voltaのパスが通ってないのでエラーになっていた

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -83,7 +83,7 @@ function install_neovim () {
 function install_volta () {
   # https://volta.sh/
   curl https://get.volta.sh | bash
-  volta install node@latest
+  ~/.volta/bin/volta install node@latest
 }
 
 function main () {


### PR DESCRIPTION
voltaは`~/.volta/bin/volta`が実体なので、それを直接指定するようにした。