### PR TITLE
setup.shの出力を抑える

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux pipefail
+set -ex pipefail
 
 function log () {
   echo [`date -Ins`] $1


### PR DESCRIPTION
`set -x`は実行コマンドを表示する設定。デバッグ用に使うのは有用だけど何でもかんでも出力するのは邪魔なので抑制する。