### PR TITLE
lazy.nvimのウィンドウが消せない問題の解消

### DIFF
--- a/home/dot_config/nvim/lua/config/filer.lua
+++ b/home/dot_config/nvim/lua/config/filer.lua
@@ -14,25 +14,6 @@ require("neo-tree").setup({
         }
     },
 })
--- 起動時にファイルエクスプローラーも開く
-vim.api.nvim_create_autocmd("VimEnter", {
-    callback = function()
-        -- Gitから開かれたときはスキップする
-        local fname = vim.fn.expand("%:t")
-        if os.getenv("GIT_INDEX_FILE")
-            or fname == "COMMIT_EDITMSG"
-            or fname == "MERGE_MSG"
-            or fname == "TAG_EDITMSG" then
-                return
-        end
-
-        vim.cmd("Neotree filesystem reveal left")
-        -- ファイルが指定されていたらそちらにフォーカスする
-        if vim.fn.argc() > 0 then
-            vim.cmd("wincmd l")
-        end
-    end,
-})
 -- Ctrl-N でトグル
 vim.keymap.set("n", "<C-n>", ":Neotree toggle<CR>")
 


### PR DESCRIPTION
neovim起動時に

1. lazy.nvimが起動
2. neo-tree起動

という順で処理が進んでいて、lazy.nvimのウィンドウに戻れず
`:q`を実行するとlazy.nvimの後ろのウィンドウが閉じられて
neovimのプロセス全体が終了してしまっていた（おそらく）。
よく考えたらneo-treeは起動しなくてもいいのでその設定を外した。