### PR TITLE
Python開発環境のLSP設定

### DIFF
--- a/home/dot_config/nvim/lua/config/lsp.lua
+++ b/home/dot_config/nvim/lua/config/lsp.lua
@@ -28,15 +28,19 @@ vim.lsp.config("lua_ls", {
         }
     },
 })
-vim.lsp.config("ruff", {
-    cmd = { "uv", "run", "ruff", "server" },
-})
-vim.lsp.config("ty", {
-    cmd = { "uv", "run", "ty", "server" },
-})
-vim.lsp.enable("ruff")
-vim.lsp.enable("ty")
 vim.lsp.enable(ensure_installed)
+if vim.uv.fs_stat(vim.fn.getcwd() .. "/.venv/bin/ruff") then
+    vim.lsp.config("ruff", {
+        cmd = { "uv", "run", "ruff", "server" },
+    })
+    vim.lsp.enable("ruff")
+end
+if vim.uv.fs_stat(vim.fn.getcwd() .. "/.venv/bin/ty") then
+    vim.lsp.config("ty", {
+        cmd = { "uv", "run", "ty", "server" },
+    })
+    vim.lsp.enable("ty")
+end
 
 -- キーマップの設定
 -- カーソル下の変数の情報


### PR DESCRIPTION
- pyrightからruff, tyに変更
  - Neovimはプロジェクトルートディレクトリで起動する前提
  - `uv run`によってLSを起動する
  - このためMasonではruff, tyは管理しない（`uv add --group dev`でプロジェクトに追加する想定）
- ファイル保存時にruffによるフォーマットを実施
  - Neovimの標準機能だけでフォーマットの実施が可能(`vim.lsp.buf.format`)

Close #24 
