### PR TITLE
neovimのキーマップを一つの設定ファイルに集約

### DIFF
--- a/home/dot_config/nvim/init.lua
+++ b/home/dot_config/nvim/init.lua
@@ -2,4 +2,6 @@ require("base")
 require("init_lazy")
 
 require("config.color-schema")
+require("config.abbrev")
+require("config.keymaps")
 require("config.lsp")

--- a/home/dot_config/nvim/lua/base.lua
+++ b/home/dot_config/nvim/lua/base.lua
@@ -6,9 +6,6 @@ vim.opt.shiftwidth = 4
 vim.opt.autoindent = true
 vim.opt.smartindent = true
 
--- mode切り替え
-vim.keymap.set("i", "jj", "<Esc>", { noremap = true, silent = true })
-
 -- クリップボード
 vim.opt.clipboard:append("unnamedplus")
 
@@ -20,10 +17,6 @@ vim.opt.relativenumber = true
 vim.opt.cursorline = true
 vim.opt.cursorcolumn = true
 vim.api.nvim_set_hl(0, "CursorColumn", { bg = "#21223a" })
-
--- Ctrl-S 保存
-vim.keymap.set("n", "<C-s>", "<Cmd>w<CR>", { silent = true })
-vim.keymap.set("i", "<C-s>", "<Esc><Cmd>w<CR>a", { silent = true })
 
 -- h,l で行跨ぎ
 vim.opt.whichwrap = { ["<"] = true, [">"] = true, h = true, l = true }

--- a/home/dot_config/nvim/lua/config/keymaps.lua
+++ b/home/dot_config/nvim/lua/config/keymaps.lua
@@ -1,0 +1,35 @@
+vim.keymap.set("n", ";", ":", { noremap = true, desc = "Command mode" })
+
+-- ページ移動
+vim.keymap.set("i", "<C-f>", "<C-o><C-f>", { noremap = true, desc = "Page down" })
+vim.keymap.set("i", "<C-b>", "<C-o><C-b>", { noremap = true, desc = "Page up" })
+
+-- normalモードに移る
+vim.keymap.set("i", "jj", "<Esc>", { noremap = true, desc = "Change to normal mode" })
+vim.keymap.set("t", "jj", [[<C-\><C-n>]], { noremap = true, desc = "Change to normal mode" })
+vim.keymap.set("t", "<Esc>", [[<C-\><C-n>]], { noremap = true, desc = "Change to normal mode" })
+
+-- Ctrl-S 保存
+vim.keymap.set({ "n", "i", "v" }, "<C-s>", "<Cmd>w<CR>", { noremap = true, desc = "Save file" })
+
+-- buffer
+vim.keymap.set("n", "<C-l>", "<Cmd>bnext<CR>", { noremap = true, desc = "Move to next buffer" })
+vim.keymap.set("n", "<C-h>", "<Cmd>bprev<CR>", { noremap = true, desc = "Move to prev buffer" })
+vim.keymap.set("n", "<leader>w", "<Cmd>bw<CR>", { noremap = true, desc = "Close current buffer" })
+
+-- 検索ハイライトの解除
+vim.keymap.set("n", "<Esc><Esc>", "<Cmd>noh<CR>", { noremap = true, desc = "No search highlight" })
+
+-- LSP
+-- 表示
+vim.keymap.set("n", "K", vim.lsp.buf.hover, { noremap = true, desc = "Hover info" })
+vim.keymap.set("n", "gr", vim.lsp.buf.references, { noremap = true, desc = "Show references" })
+-- ジャンプ
+vim.keymap.set("n", "gd", vim.lsp.buf.definition, { noremap = true, desc = "Go to definition" })
+vim.keymap.set("n", "gD", vim.lsp.buf.declaration, { noremap = true, desc = "Go to definition" })
+vim.keymap.set("n", "gt", "<C-t>", { noremap = true, desc = "Jump back" })
+-- 編集
+vim.keymap.set({ "n", "i" }, "<F2>", vim.lsp.buf.rename, { noremap = true, desc = "Rename symbol" })
+vim.keymap.set("n", "gf", vim.lsp.buf.format, { noremap = true, desc = "Format buffer" })
+vim.keymap.set({ "n", "i" }, "<A-S-f>", vim.lsp.buf.format, { noremap = true, desc = "Format buffer" })
+vim.keymap.set({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, { desc = "Code action" })

--- a/home/dot_config/nvim/lua/config/lsp.lua
+++ b/home/dot_config/nvim/lua/config/lsp.lua
@@ -26,20 +26,6 @@ if vim.uv.fs_stat(vim.fn.getcwd() .. "/.venv/bin/ty") then
   vim.lsp.enable("ty")
 end
 
--- キーマップの設定
--- カーソル下の変数の情報
-vim.keymap.set("n", "K", "<cmd>lua vim.lsp.buf.hover()<CR>")
--- 定義ジャンプ
-vim.keymap.set("n", "gd", "<cmd>lua vim.lsp.buf.definition()<CR>")
--- 定義ジャンプ後に下のファイルに戻る
-vim.keymap.set("n", "gt", "<C-t>")
--- 改行やインデントなどのフォーマット
-vim.keymap.set("n", "gf", "<cmd>lua vim.lsp.buf.formatting()<CR>")
--- カーソル下の変数をコード内で参照している箇所
-vim.keymap.set("n", "gr", "<cmd>lua vim.lsp.buf.references()<CR>")
--- 変数名のリネーム
-vim.keymap.set("n", "gn", "<cmd>lua vim.lsp.buf.rename()<CR>")
-
 -- 自動フォーマット
 vim.api.nvim_create_autocmd("LspAttach", {
   callback = function(args)

--- a/home/dot_config/nvim/lua/plugins/bufferline.lua
+++ b/home/dot_config/nvim/lua/plugins/bufferline.lua
@@ -11,9 +11,4 @@ return {
       options = {},
     })
   end,
-  keys = {
-    { "<leader>l", "<Cmd>bnext<CR>", mode = { "n", "i" } },
-    { "<leader>h", "<Cmd>bprev<CR>", mode = { "n", "i" } },
-    { "<leader>w", "<Cmd>bw<CR>", mode = { "n", "i" } },
-  },
 }

--- a/home/dot_config/nvim/lua/plugins/toggleterm.lua
+++ b/home/dot_config/nvim/lua/plugins/toggleterm.lua
@@ -3,11 +3,6 @@ return {
     "akinsho/toggleterm.nvim",
     version = "*",
     config = function()
-      -- ターミナルモードから抜けるための設定
-      -- TODO: keymaps.luaに移動
-      vim.keymap.set("t", "<Esc>", [[<C-\><C-n>]], { noremap = true })
-      vim.keymap.set("t", "jj", [[<C-\><C-n>]], { noremap = true })
-
       require("toggleterm").setup({
         -- 同じキーを入力するとターミナルを閉じることができる
         open_mapping = [[<leader>@]],


### PR DESCRIPTION
`lua/config/keymaps.lua`に集約。ただし、プラグインの機能を使うキーマップはプラグイン側で設定する。