### PR TITLE
画面上部にナビゲーションを追加

### DIFF
--- a/home/dot_config/nvim/lua/plugins/dropbar.lua
+++ b/home/dot_config/nvim/lua/plugins/dropbar.lua
@@ -1,0 +1,9 @@
+return {
+  "Bekaboo/dropbar.nvim",
+  config = function()
+    local dropbar_api = require("dropbar.api")
+    vim.keymap.set("n", "<Leader>;", dropbar_api.pick, { desc = "Pick symbols in winbar" })
+    vim.keymap.set("n", "[;", dropbar_api.goto_context_start, { desc = "Go to start of current context" })
+    vim.keymap.set("n", "];", dropbar_api.select_next_context, { desc = "Select next context" })
+  end,
+}


### PR DESCRIPTION
[dropbar.nvim](https://github.com/Bekaboo/dropbar.nvim)というプラグインを使う。
README.mdにあった設定を入れたがショートカットは使うことないと思う。